### PR TITLE
Fix handling http client error

### DIFF
--- a/merger/merge.go
+++ b/merger/merge.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"golang.org/x/sync/errgroup"
@@ -24,13 +23,19 @@ func (m *merger) merge(ctx context.Context, w io.Writer) error {
 		g.Go(func() error {
 			resp, err := m.client.Get(source.url)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("get url: %s", source.url))
+				fmt.Printf("get url: %s", source.url)
+				return nil
 			}
-			defer resp.Body.Close()
+			defer func(Body io.ReadCloser) {
+				err := Body.Close()
+				if err != nil {
+				}
+			}(resp.Body)
 			tp := new(expfmt.TextParser)
 			out, err := tp.TextToMetricFamilies(resp.Body)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("parse url: %s", source.url))
+				fmt.Printf("parse url: %s", source.url)
+				return nil
 			}
 			mu.Lock()
 			defer mu.Unlock()

--- a/merger/merge.go
+++ b/merger/merge.go
@@ -26,11 +26,7 @@ func (m *merger) merge(ctx context.Context, w io.Writer) error {
 				fmt.Printf("get url: %s", source.url)
 				return nil
 			}
-			defer func(Body io.ReadCloser) {
-				err := Body.Close()
-				if err != nil {
-				}
-			}(resp.Body)
+			defer resp.Body.Close()
 			tp := new(expfmt.TextParser)
 			out, err := tp.TextToMetricFamilies(resp.Body)
 			if err != nil {


### PR DESCRIPTION
If one of the target URLs was not a listen, no metrics were responded to.
This action is not what I expect, so I will modify the behavior to return metrics even if there is an error URL.